### PR TITLE
Refactoring

### DIFF
--- a/vite/preset.js
+++ b/vite/preset.js
@@ -1,34 +1,36 @@
 const path = require("path");
 const fs = require("fs");
 
-const MOCKS_DIRECTORY = "__mocks__";
+const createManualMocksPlugin = (mocksDirectoryPath) => {
+  return function parcelManualMocksPlugin() {
+    return {
+      name: "manual-mocks-plugin",
+      load(_importPath) {
+        const importPath = _importPath.replace(/\0/g, "");
+        const basePath = path.parse(importPath);
+        const mockPath = path.join(
+          basePath.dir,
+          mocksDirectoryPath,
+          basePath.base
+        );
+        const isReplacementPathExists = fs.existsSync(mockPath);
+        if (isReplacementPathExists) {
+          return fs.readFileSync(mockPath, { encoding: "utf8" });
+        }
+      },
+    };
+  };
+};
 
 module.exports = {
   async viteFinal(config, context) {
     const { mergeConfig } = await import("vite");
-    const MOCKS_DIRECTORY = context.mocksFolder || "__mocks__";
-
-    function parcelMocksPlugin() {
-      return {
-        name: "mocks-plugin",
-        load(_importPath) {
-          const importPath = _importPath.replace(/\0/g, "");
-          const basePath = path.parse(importPath);
-          const mockPath = path.join(
-            basePath.dir,
-            MOCKS_DIRECTORY,
-            basePath.base
-          );
-          const isReplacementPathExists = fs.existsSync(mockPath);
-          if (isReplacementPathExists) {
-            return fs.readFileSync(mockPath, { encoding: "utf8" });
-          }
-        },
-      };
-    }
+    const parcelManualMocksPlugin = createManualMocksPlugin(
+      context.mocksFolder || "__mocks__"
+    );
 
     return mergeConfig(config, {
-      plugins: [parcelMocksPlugin()],
+      plugins: [parcelManualMocksPlugin()],
     });
   },
 };

--- a/vite/preset.js
+++ b/vite/preset.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const fs = require("fs");
 
-const createManualMocksPlugin = (mocksDirectoryPath) => {
+const createViteManualMocksPlugin = (mocksDirectoryPath) => {
   return function parcelManualMocksPlugin() {
     return {
       name: "manual-mocks-plugin",
@@ -25,7 +25,7 @@ const createManualMocksPlugin = (mocksDirectoryPath) => {
 module.exports = {
   async viteFinal(config, context) {
     const { mergeConfig } = await import("vite");
-    const parcelManualMocksPlugin = createManualMocksPlugin(
+    const parcelManualMocksPlugin = createViteManualMocksPlugin(
       context.mocksFolder || "__mocks__"
     );
 

--- a/vite/preset.js
+++ b/vite/preset.js
@@ -1,16 +1,16 @@
 const path = require("path");
 const fs = require("fs");
 
-const createViteManualMocksPlugin = (mocksDirectoryPath) => {
+const createViteManualMocksDirectoryPlugin = (mocksFolderPath) => {
   return function parcelManualMocksPlugin() {
     return {
-      name: "manual-mocks-plugin",
+      name: "manual-mocks-directory-plugin",
       load(_importPath) {
         const importPath = _importPath.replace(/\0/g, "");
         const basePath = path.parse(importPath);
         const mockPath = path.join(
           basePath.dir,
-          mocksDirectoryPath,
+          mocksFolderPath,
           basePath.base
         );
         const isReplacementPathExists = fs.existsSync(mockPath);
@@ -22,12 +22,46 @@ const createViteManualMocksPlugin = (mocksDirectoryPath) => {
   };
 };
 
+const createViteManualMocksPostfixPlugin = () => {
+  function parcelMocksPlugin() {
+    return {
+      name: "manual-mocks-postfix-plugin",
+      load(_importPath) {
+        const importPath = _importPath.replace(/\0/g, "");
+        const basePath = path.parse(importPath);
+        const mockPath = path.join(
+          basePath.dir,
+          basePath.base
+            .replace(/\.js$/, ".mock.js")
+            .replace(/\.ts$/, ".mock.ts")
+            .replace(/\.jsx$/, ".mock.jsx")
+            .replace(/\.tsx$/, ".mock.tsx")
+        );
+
+        const isReplacementPathExists = fs.existsSync(mockPath);
+        if (isReplacementPathExists) {
+          return fs.readFileSync(mockPath, { encoding: "utf8" });
+        }
+      },
+    };
+  }
+};
+
+const createViteManualMocksPlugin = (config) => {
+  if (config.approach === "directory") {
+    return createViteManualMocksDirectoryPlugin(config.mocksFolder);
+  } else if (config.approach === "postfix") {
+    return createViteManualMocksPostfixPlugin();
+  }
+};
+
 module.exports = {
   async viteFinal(config, context) {
     const { mergeConfig } = await import("vite");
-    const parcelManualMocksPlugin = createViteManualMocksPlugin(
-      context.mocksFolder || "__mocks__"
-    );
+    const parcelManualMocksPlugin = createViteManualMocksPlugin({
+      approach: context.approach || "directory",
+      mocksFolder: context.mocksFolder || "__mocks__",
+    });
 
     return mergeConfig(config, {
       plugins: [parcelManualMocksPlugin()],

--- a/webpack/preset.js
+++ b/webpack/preset.js
@@ -1,50 +1,58 @@
 const path = require("path");
 const fs = require("fs");
 
+const createWebpackManualMocksPlugins = (mocksDirectoryPath = "__mocks__") => {
+  const webpack = require("webpack");
+  const EXTENSIONS = [".ts", ".js"];
+  const plugins = [];
+
+  plugins.push(
+    new webpack.NormalModuleReplacementPlugin(/^\.\//, async (resource) => {
+      const mockedPath = path.resolve(
+        resource.context,
+        mocksDirectoryPath,
+        resource.request
+      );
+      for (let ext of EXTENSIONS) {
+        const isReplacementPathExists = fs.existsSync(mockedPath + ext);
+        if (isReplacementPathExists) {
+          const newImportPath =
+            "./" + path.join(MOCKS_DIRECTORY, resource.request);
+          resource.request = newImportPath;
+          break;
+        }
+      }
+    })
+  );
+
+  plugins.push(
+    new webpack.NormalModuleReplacementPlugin(/^\.\.\//, async (resource) => {
+      const prs = path.parse(resource.request);
+      const mockedPath = path.resolve(
+        resource.context,
+        prs.dir,
+        mocksDirectoryPath,
+        prs.base
+      );
+      for (let ext of EXTENSIONS) {
+        const isReplacementPathExists = fs.existsSync(mockedPath + ext);
+        if (isReplacementPathExists) {
+          const newImportPath =
+            prs.dir + "/" + path.join(MOCKS_DIRECTORY, prs.base);
+          resource.request = newImportPath;
+          break;
+        }
+      }
+    })
+  );
+
+  return plugins;
+};
+
 module.exports = {
   webpackFinal: (config, context) => {
-    const webpack = require("webpack");
-    const EXTENSIONS = [".ts", ".js"];
-    const MOCKS_DIRECTORY = context.mocksFolder || "__mocks__";
-
     config.plugins.push(
-      new webpack.NormalModuleReplacementPlugin(/^\.\//, async (resource) => {
-        const mockedPath = path.resolve(
-          resource.context,
-          MOCKS_DIRECTORY,
-          resource.request
-        );
-        for (let ext of EXTENSIONS) {
-          const isReplacementPathExists = fs.existsSync(mockedPath + ext);
-          if (isReplacementPathExists) {
-            const newImportPath =
-              "./" + path.join(MOCKS_DIRECTORY, resource.request);
-            resource.request = newImportPath;
-            break;
-          }
-        }
-      })
-    );
-
-    config.plugins.push(
-      new webpack.NormalModuleReplacementPlugin(/^\.\.\//, async (resource) => {
-        const prs = path.parse(resource.request);
-        const mockedPath = path.resolve(
-          resource.context,
-          prs.dir,
-          MOCKS_DIRECTORY,
-          prs.base
-        );
-        for (let ext of EXTENSIONS) {
-          const isReplacementPathExists = fs.existsSync(mockedPath + ext);
-          if (isReplacementPathExists) {
-            const newImportPath =
-              prs.dir + "/" + path.join(MOCKS_DIRECTORY, prs.base);
-            resource.request = newImportPath;
-            break;
-          }
-        }
-      })
+      ...createWebpackManualMocksPlugins(context.mocksFolder || "__mocks__")
     );
 
     return config;


### PR DESCRIPTION
 - [x] Move webpack and vite related code outside of the storybook preset
 - [ ] Add new mocking approaches https://github.com/gebeto/storybook-addon-manual-mocks/issues/20
     - [ ] for `webpack`
     - [x] for `vite`
 - [ ] Add bundler agnostic helpers to check and transform paths to be able to reuse it in `vite` and `webpack`
 - [ ] Add tests